### PR TITLE
Remove unnecessary Future.delayed() from SideMenu.dispose()

### DIFF
--- a/lib/src/side_menu.dart
+++ b/lib/src/side_menu.dart
@@ -348,10 +348,7 @@ class _SideMenuState extends State<SideMenu> {
 
   @override
   void dispose() {
-    Future.delayed(Duration.zero, () {
-      widget.global.displayModeState
-          .change(widget.global.displayModeState.value);
-    });
+    widget.global.displayModeState.change(widget.global.displayModeState.value);
     super.dispose();
   }
 }


### PR DESCRIPTION
It seems to be unnecessary to call Future.delayed() inside the SideMenu.dispose() method, and doing so causes async tests to fail with the timer still pending error:
```
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following assertion was thrown running a test:
A Timer is still pending even after the widget tree was disposed.
'package:flutter_test/src/binding.dart':
Failed assertion: line 1527 pos 12: '!timersPending'

When the exception was thrown, this was the stack:
#2      AutomatedTestWidgetsFlutterBinding._verifyInvariants (package:flutter_test/src/binding.dart:1527:12)
#3      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1034:7)
```

Removing solves this problem without seeming to cause any issues.